### PR TITLE
fix: json fields copyable decoration ( MAPCO-3635 )

### DIFF
--- a/src/common/ui-aspects/record-3d-fields.ui-aspects.ts
+++ b/src/common/ui-aspects/record-3d-fields.ui-aspects.ts
@@ -106,6 +106,7 @@ const pycsw3DCatalogRecordAspects = {
   footprint: {
     label: 'field-names.3d.footprint',
     fullWidth: true,
+    isCopyable: true,
   },
   heightRangeFrom: {
     label: 'field-names.3d.heightRangeFrom',

--- a/src/common/ui-aspects/record-dem-fields.ui-aspects.ts
+++ b/src/common/ui-aspects/record-dem-fields.ui-aspects.ts
@@ -92,6 +92,7 @@ const pycswDemCatalogRecordAspects = {
   layerPolygonParts: {
     label: 'field-names.dem.layerPolygonParts',
     fullWidth: true,
+    isCopyable: true,
   },
   heightRangeFrom: {
     label: 'field-names.dem.heightRangeFrom',

--- a/src/common/ui-aspects/record-quantized-mesh-best-fields.ui-aspects.ts
+++ b/src/common/ui-aspects/record-quantized-mesh-best-fields.ui-aspects.ts
@@ -88,6 +88,7 @@ export const pycswQuantizedMeshBestCatalogRecordAspects = {
   footprint: {
     label: 'field-names.quantized-mesh.footprint',
     fullWidth: true,
+    isCopyable: true,
   },
   heightRangeFrom: {
     label: 'field-names.quantized-mesh.heightRangeFrom',

--- a/src/common/ui-aspects/record-raster-fields.ui-aspects.ts
+++ b/src/common/ui-aspects/record-raster-fields.ui-aspects.ts
@@ -201,6 +201,7 @@ const pycswLayerCatalogRecordAspects = {
   footprint: {
     label: 'field-names.raster.footprint',
     fullWidth: true,
+    isCopyable: true,
   },
   producerName: {
     label: 'field-names.raster.producerName',
@@ -209,6 +210,7 @@ const pycswLayerCatalogRecordAspects = {
   layerPolygonParts: {
     label: 'field-names.raster.layerPolygonParts',
     fullWidth: true,
+    isCopyable: true,
   },
   transparency: {
     label: 'field-names.raster.transparency',

--- a/src/common/ui-aspects/record-vector-best-fields.ui-aspects.ts
+++ b/src/common/ui-aspects/record-vector-best-fields.ui-aspects.ts
@@ -76,6 +76,8 @@ export const pycswVectorBestCatalogRecordAspects = {
   },
   footprint: {
     label: 'field-names.vector-raster.footprint',
+    fullWidth: true,
+    isCopyable: true,
   },
   id: {
     label: 'field-names.vector-raster.id',


### PR DESCRIPTION
Define for all entities json fields(footprint/polygonparts) as copyable